### PR TITLE
Correct typo in word count validation message

### DIFF
--- a/freetextresponse/freetextresponse.py
+++ b/freetextresponse/freetextresponse.py
@@ -286,9 +286,9 @@ class FreeTextResponse(StudioEditableXBlockMixin, XBlock):
         result = ''
         if self.count_attempts > 0 and not self._word_count_valid():
             result = ungettext(
-                "Invalid Word Count. Your reponse must be "
+                "Invalid Word Count. Your response must be "
                 "between {min} and {max} word.",
-                "Invalid Word Count. Your reponse must be "
+                "Invalid Word Count. Your response must be "
                 "between {min} and {max} words.",
                 self.max_word_count,
             ).format(

--- a/freetextresponse/tests.py
+++ b/freetextresponse/tests.py
@@ -149,7 +149,7 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
         self.xblock.count_attempts = 5
         self.xblock._word_count_valid = MagicMock(return_value=False)
         self.assertIn(
-            _('Invalid Word Count. Your reponse must be between'),
+            _('Invalid Word Count. Your response must be between'),
             self.xblock._get_word_count_message()
         )
 


### PR DESCRIPTION
This commit corrects the mispelling of the word 'response'.
