### PR TITLE
Remove Credit enumeration and clean up score calculation

### DIFF
--- a/freetextresponse/freetextresponse.py
+++ b/freetextresponse/freetextresponse.py
@@ -394,13 +394,13 @@ class FreeTextResponse(StudioEditableXBlockMixin, XBlock):
         based on their answer
         """
         credit = self._determine_credit()
-        self.score = credit
+        self.score = credit.value
         self.runtime.publish(
             self,
             'grade',
             {
                 'value': self.score,
-                'max_value': Credit.full
+                'max_value': Credit.full.value
             }
         )
 

--- a/freetextresponse/tests.py
+++ b/freetextresponse/tests.py
@@ -392,7 +392,7 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
         self.xblock.runtime.publish.assert_called_with(
             self.xblock,
             'grade',
-            {'value': Credit.full, 'max_value': Credit.full},
+            {'value': Credit.full.value, 'max_value': Credit.full.value},
         )
 
     def test_compute_score_half_credit(self):
@@ -411,7 +411,7 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
         self.xblock.runtime.publish.assert_called_with(
             self.xblock,
             'grade',
-            {'value': Credit.half, 'max_value': Credit.full},
+            {'value': Credit.half.value, 'max_value': Credit.full.value},
         )
 
     def test_compute_score_no_credit(self):
@@ -430,7 +430,7 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
         self.xblock.runtime.publish.assert_called_with(
             self.xblock,
             'grade',
-            {'value': Credit.zero, 'max_value': Credit.full},
+            {'value': Credit.zero.value, 'max_value': Credit.full.value},
         )
 
     def test_indicator_visibility_class_blank(self):


### PR DESCRIPTION
Submissions were failing to go through due to incompatible score type from the Credit enum. Removed and simplified some logic and tests.
-- UPDATE: kept Enum for code clarity, fixed to use Enum value.

@stvstnfrd 
