### PR TITLE
Fix progress page max_score scoring issue

### DIFF
--- a/freetextresponse/freetextresponse.py
+++ b/freetextresponse/freetextresponse.py
@@ -246,6 +246,16 @@ class FreeTextResponse(StudioEditableXBlockMixin, XBlock):
         )
         return fragment
 
+    def max_score(self):
+        """
+        Returns the configured number of possible points for this component.
+        Arguments:
+            None
+        Returns:
+            float: The number of possible points for this component
+        """
+        return self.weight
+
     @classmethod
     def _generate_validation_message(cls, msg):
         """

--- a/freetextresponse/tests.py
+++ b/freetextresponse/tests.py
@@ -264,6 +264,14 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
             student_view_html
         )
 
+    def test_max_score(self):
+        """
+        Tests max_score function
+        Should return the weight
+        """
+        self.xblock.weight = 4
+        self.assertEquals(self.xblock.weight, self.xblock.max_score())
+
     def test_studio_view(self):
         """
         Checks studio view for instance variables specified by the instructor.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class Tox(TestCommand):
 
 setup(
     name="xblock-free-text-response",
-    version="0.1.1",
+    version="0.1.2",
     description="Enables instructors to create questions with free-text responses.",
     license='AGPL-3.0',
     packages=[


### PR DESCRIPTION
max_score function needs to be included in
xblocks so the LMS progress page correctly
reports the progress for a subsection. Not
fixing this is confusing to the student and
could result in grading errors.

@kluo @stvstnfrd PR for fixing progress issue by adding max_score function to xblock.

https://trello.com/c/PqrXDAYi/669-graded-xblocks-not-correctly-reflected-in-grading