### PR TITLE
Fix prompt html support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,7 +120,6 @@ module.exports = function (grunt) {
                     gruntFile,
                     directoryPrivateJsAll,
                     directoryPrivateLessAll,
-                    directoryPrivateHtmlAll,
                 ],
                 tasks: [
                     'default',

--- a/freetextresponse/templates/freetextresponse_view.html
+++ b/freetextresponse/templates/freetextresponse_view.html
@@ -2,7 +2,7 @@
 <div class="freetextresponse xmodule_display xmodule_CapaModule problem">
     <h2 class="problem-header">{{ display_name }}</h2>
     <div class="problem-progress">{{ problem_progress }}</div>
-    <p>{{ prompt }}</p>
+    <p>{{ prompt|safe }}</p>
     <div class="word-count-message">{{ word_count_message }}</div>
     <div class="capa_inputtype textline">
         <div class="user_input {{ indicator_class }}">

--- a/freetextresponse/tests.py
+++ b/freetextresponse/tests.py
@@ -12,6 +12,8 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import DictFieldData
 from xblock.validation import ValidationMessage
 
+from django.template.loader import get_template
+
 from .freetextresponse import Credit
 from .freetextresponse import FreeTextResponse
 
@@ -166,6 +168,28 @@ class FreetextResponseXblockTestCase(unittest.TestCase):
             self.xblock._get_indicator_visibility_class(),
             student_view_html
         )
+
+    def test_build_fragment_prompt_html(self):
+        """
+        Checks that build_fragment allows html in the prompt variable
+
+        if the 'safe' filter is not used then the django
+        template pipeline returns html tags like,
+            '&lt;p&gt;Please enter your response here&lt;/p&gt;'
+        """
+        studio_settings_prompt = "<p>Please enter your response here</p>"
+        context = {
+            'prompt': studio_settings_prompt,
+        }
+        template = get_template('freetextresponse_view.html')
+        fragment = self.xblock.build_fragment(
+            template,
+            context,
+            initialize_js_func='FreeTextResponseView',
+            additional_css=[],
+            additional_js=[],
+        )
+        self.assertIn(studio_settings_prompt, fragment.content)
 
     def test_max_score(self):
         """

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-free-text-response",
   "title": "FreeTextResponse XBlock",
   "description": "Enables instructors to create questions with free-text responses.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/Stanford-Online/xblock-free-text-response",
   "author": {
     "name": "Azim Pradhan",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class Tox(TestCommand):
 
 setup(
     name="xblock-free-text-response",
-    version="0.1.3",
+    version="0.1.4",
     description="Enables instructors to create questions with free-text responses.",
     license='AGPL-3.0',
     packages=[


### PR DESCRIPTION
@kluo @caesar2164 PR to fix TWO bugs created when we switched to django templates for this xblock.

The first bug is a development one.  grunt no longer needs to watch the html file but I left the dir in the Gruntfile.

Second is a UI bug fix from the trello card, 

https://trello.com/c/41a2vUOR/903-fix-prompt-html-support-for-free-text-response-the-free-text-response-xblock-prompt-field-used-to-support-html-but-now-is-displa

Instructors previously added html to the prompt in Studio settings.  Django template variables need a autoescape tag 'safe' added to all html. 
 Django docs: https://docs.djangoproject.com/en/dev/ref/templates/builtins/  