### PR TITLE
Suppress IntegrityError exception

### DIFF
--- a/freetextresponse/freetextresponse.py
+++ b/freetextresponse/freetextresponse.py
@@ -2,6 +2,7 @@
 This is the core logic for the Free-text Response XBlock
 """
 from enum import Enum
+from django.db import IntegrityError
 from django.template.context import Context
 from django.template.loader import get_template
 from django.utils.translation import ungettext
@@ -454,14 +455,17 @@ class FreeTextResponse(StudioEditableXBlockMixin, XBlock):
         """
         credit = self._determine_credit()
         self.score = credit.value
-        self.runtime.publish(
-            self,
-            'grade',
-            {
-                'value': self.score,
-                'max_value': Credit.full.value
-            }
-        )
+        try:
+            self.runtime.publish(
+                self,
+                'grade',
+                {
+                    'value': self.score,
+                    'max_value': Credit.full.value
+                }
+            )
+        except IntegrityError:
+            pass
 
     def _determine_credit(self):
         #  Not a standard xlbock pylint disable.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xblock-free-text-response",
   "title": "FreeTextResponse XBlock",
   "description": "Enables instructors to create questions with free-text responses.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://github.com/Stanford-Online/xblock-free-text-response",
   "author": {
     "name": "Azim Pradhan",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class Tox(TestCommand):
 
 setup(
     name="xblock-free-text-response",
-    version="0.1.5",
+    version="0.1.6",
     description="Enables instructors to create questions with free-text responses.",
     license='AGPL-3.0',
     packages=[


### PR DESCRIPTION
Added code to catch – and ignore – The
IntegrityError exception. Created a new
unit test that mocks the exception
in question to ensure that it is
gracefully ignored.

@caseylitton  @potsui @jspayd

### Release Notes
---

* Previously, a call to _compute_score could potentially yield an IntegrityError exception that had no handler.
* This change fixes that by wrapping a segment of _compute_score in a try-except and ignoring the IntegrityError exception.
* The change also includes unit tests to ensure that the exception is indeed being handled.