### PR TITLE
Toggle text when showing and hiding peer responses

### DIFF
--- a/freetextresponse/public/view.css
+++ b/freetextresponse/public/view.css
@@ -126,6 +126,12 @@
   text-decoration: underline;
   text-shadow: none;
 }
+.freetextresponse .hide-button .show {
+  display: none;
+}
+.freetextresponse .hide-button .hide {
+  display: inline;
+}
 
 .freetextresponse .response-list {
   list-style: none;

--- a/freetextresponse/public/view.js
+++ b/freetextresponse/public/view.js
@@ -5,6 +5,8 @@ function FreeTextResponseView(runtime, element) {
     var $element = $(element);
     var $xblocksContainer = $('#seq_content');
     var buttonHide = $element.find('.hide-button');
+    var buttonHideTextHide = $('.hide', buttonHide);
+    var buttonHideTextShow = $('.show', buttonHide);
     var buttonSubmit = $element.find('.check.Submit');
     var buttonSave = $element.find('.save');
     var usedAttemptsFeedback = $element.find('.action .used-attempts-feedback');
@@ -41,6 +43,8 @@ function FreeTextResponseView(runtime, element) {
 
     buttonHide.on('click', function () {
         responseList.toggle();
+        buttonHideTextHide.toggle();
+        buttonHideTextShow.toggle();
     });
 
     buttonSubmit.on('click', function () {

--- a/freetextresponse/templates/freetextresponse_view.html
+++ b/freetextresponse/templates/freetextresponse_view.html
@@ -31,7 +31,11 @@
     <div class="capa_alert user_alert">{{ user_alert }}</div>
     {% if display_other_responses %}
         <div class="responses-box">
-            <button class="hide-button">Hide</button>
+            <button class="hide-button">
+                <span class="hide">Hide</span>
+                <span class="show">Show</span>
+                <span class="sr">peer responses</span>
+            </button>
             <p class="responses-title">Submissions by others</p>
             <ul class="response-list">
                 <li class="no-response">No responses to show at this time</li>


### PR DESCRIPTION
- Also improve a11y of hide button

@stvstnfrd 

When peer responses first appear:
![screen shot 2018-09-25 at 12 05 06](https://user-images.githubusercontent.com/3364609/46036815-5b6baa00-c0bb-11e8-91c5-0b26cc1dff98.png)

After Clicking "Hide":
![screen shot 2018-09-25 at 12 05 19](https://user-images.githubusercontent.com/3364609/46036840-6a525c80-c0bb-11e8-8bf9-132f4becf386.png)
